### PR TITLE
Added: timeFormatting can now be passed when initializing Agendash

### DIFF
--- a/lib/agendash.js
+++ b/lib/agendash.js
@@ -40,6 +40,9 @@ module.exports = function (agenda, options) {
     function (err, apiResponse) {
       if (err) return callback(err.message)
       apiResponse.title = options.title || 'Agendash'
+      if (options.timeFormatting) {
+        apiResponse.timeFormatting = options.timeFormatting
+      }
       apiResponse.currentRequest = {
         title: options.title || 'Agendash',
         job: job || 'All Jobs',

--- a/public/index.html
+++ b/public/index.html
@@ -129,10 +129,10 @@
       <td>
         <%- job.name %>
       </td>
-      <td><% if (job.lastRunAt) { %><time datetime="<%- moment(job.lastRunAt).toISOString() %>"><%- moment(job.lastRunAt).fromNow() %></time><% } %></td>
-      <td><% if (job.nextRunAt) { %><time datetime="<%- moment(job.nextRunAt).toISOString() %>"><%- moment(job.nextRunAt).fromNow() %></time><% } %></td>
-      <td><% if (job.lastFinishedAt) { %><time datetime="<%- moment(job.lastFinishedAt).toISOString() %>"><%- moment(job.lastFinishedAt).fromNow() %></time><% } %></td>
-      <td><% if (job.lockedAt) { %><time datetime="<%- moment(job.lockedAt).toISOString() %>"><%- moment(job.lockedAt).fromNow() %></time><% } %></td>
+      <td><% if (job.lastRunAt) { %><time datetime="<%- moment(job.lastRunAt).toISOString() %>"><%- formatDate(job.lastRunAt) %></time><% } %></td>
+      <td><% if (job.nextRunAt) { %><time datetime="<%- moment(job.nextRunAt).toISOString() %>"><%- formatDate(job.nextRunAt) %></time><% } %></td>
+      <td><% if (job.lastFinishedAt) { %><time datetime="<%- moment(job.lastFinishedAt).toISOString() %>"><%- formatDate(job.lastFinishedAt) %></time><% } %></td>
+      <td><% if (job.lockedAt) { %><time datetime="<%- moment(job.lockedAt).toISOString() %>"><%- formatDate(job.lockedAt) %></time><% } %></td>
     </script>
 
     <script type="text/template" id="job-item-details-template">
@@ -148,10 +148,10 @@
           <% if (failed) { %><span class="label label-danger">Failed</span><% } %>
         </div>
         <div class="panel-body">
-          <% if (job.lastRunAt) { %><p>Last run <time datetime="<%- moment(job.lastRunAt).toISOString() %>"><%- moment(job.lastRunAt).fromNow() %></time></p><% } %>
-          <% if (job.nextRunAt) { %><p>Next run <time datetime="<%- moment(job.nextRunAt).toISOString() %>"><%- moment(job.nextRunAt).fromNow() %></time></p><% } %>
-          <% if (job.lastFinishedAt) { %><p>Last finished <time datetime="<%- moment(job.lastFinishedAt).toISOString() %>"><%- moment(job.lastFinishedAt).fromNow() %></time></p><% } %>
-          <% if (job.lockedAt) { %><p>Locked <time datetime="<%- moment(job.lockedAt).toISOString() %>"><%- moment(job.lockedAt).fromNow() %></time></p><% } %>
+          <% if (job.lastRunAt) { %><p>Last run <time datetime="<%- moment(job.lastRunAt).toISOString() %>"><%- formatDate(job.lastRunAt) %></time></p><% } %>
+          <% if (job.nextRunAt) { %><p>Next run <time datetime="<%- moment(job.nextRunAt).toISOString() %>"><%- formatDate(job.nextRunAt) %></time></p><% } %>
+          <% if (job.lastFinishedAt) { %><p>Last finished <time datetime="<%- moment(job.lastFinishedAt).toISOString() %>"><%- formatDate(job.lastFinishedAt) %></time></p><% } %>
+          <% if (job.lockedAt) { %><p>Locked <time datetime="<%- moment(job.lockedAt).toISOString() %>"><%- formatDate(job.lockedAt) %></time></p><% } %>
           <% if (job.repeatInterval) { %><p>Repeat each <%- job.repeatInterval %></p><% } %>
 
           <strong>Job data</strong>


### PR DESCRIPTION
I started from the idea of @kfiroo in https://github.com/joeframbach/agendash/pull/44 but instead of forcing yet an other format (here `ISOString` instead of `fromNow`), I added the possibility to set any format when initializing agendash.
```
expressApp.use('/agendash',
    agendash(agenda, {
        title: 'My jobs',
        timeFormatting: {
            type: 'format',
            value: 'DD/MM/YYYY HH:mm:ss'
        }
    })
);
```

Example of other valid formats:
`{type: 'function', value: 'fromNow'}` <- default
`{type: 'function', value: 'toISOString'}` <- @kfiroo choice
`{type: 'format', value: 'LLL'}`
`{type: 'format', value: 'DD/MM/YYYY HH:mm:ss'}`
(anything from Moments.js can be used)

:information_source: I didn't update the doc in my branch since I'm waiting for the change itself to be accepted