### PR TITLE
Add Dockerfile to build a agendash docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,8 @@
+FROM cusspvz/node:latest
+MAINTAINER José Moreira <josemoreiravarzim@gmail.com>
+
+ARG VERSION=latest
+RUN npm install -g agendash@${VERSION}
+
+EXPOSE 3000
+CMD [ "agendash" ]


### PR DESCRIPTION
Run example:

```bash
cd docker/
docker build -t agendash .
docker run -d mongo
docker run -d --link mongo:mongo -p 3000:3000 agendash --db=mongodb://mongo/test
open http://localhost:3000
```