### PR TITLE
Add entrypoint to change mongodb uri and collection from env

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,10 @@ FROM node:8.2.0-alpine
 # RUN apk update && apk upgrade && \
 #    apk add --no-cache bash gawk sed grep bc coreutils git openssh
 
+ENV NODE_ENV=production \
+  MONGODB_URI=mongodb://mongodb \
+  COLLECTION=agendaJobs
+
 RUN mkdir -p /agendash
 WORKDIR /agendash
 
@@ -11,6 +15,8 @@ COPY package.json /agendash/
 RUN npm install && npm cache clean --force
 
 COPY . /agendash
+RUN chmod +x /agendash/entrypoint.sh
 
-ENTRYPOINT ["node", "./bin/agendash-standalone.js"]
-CMD ["--db=mongodb://mongodb"]
+EXPOSE 3000
+
+ENTRYPOINT ["/agendash/entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+
+set +e
+
+exec node ./bin/agendash-standalone.js --db=$MONGODB_URI --collection=$COLLECTION


### PR DESCRIPTION
Enable change default mongodb uri and collection via environment variables.

Example:

```bash
docker run -d --name agendash -p 3000:3000 \
  -e MONGODB_URI=mongo://myuser:mypass@mycutommongohost/otherdb \
  -e COLLECTION=customCollection agenda/agendash
```