### PR TITLE
defensive version check

### DIFF
--- a/lib/agendash.js
+++ b/lib/agendash.js
@@ -15,14 +15,16 @@ module.exports = function(agenda, options) {
         console.warn('Agendash indexes might not exist. Performance may decrease.');
       }
     });
-    agenda._mdb.admin().serverInfo((err, serverInfo) => {
-      if (err) {
-        throw err;
-      }
-      if (!semver.satisfies(serverInfo.version, '>=2.6.0')) {
-        console.warn('Agendash requires mongodb version >=2.6.0.');
-      }
-    });
+    if (typeof agenda._mdb.admin === 'function') {
+      agenda._mdb.admin().serverInfo((err, serverInfo) => {
+        if (err) {
+          throw err;
+        }
+        if (!semver.satisfies(serverInfo.version, '>=2.6.0')) {
+          console.warn('Agendash requires mongodb version >=2.6.0.');
+        }
+      });
+    }
   });
 
   const getJobs = (job, state, callback) => {


### PR DESCRIPTION
I got error `TypeError: agenda._mdb.admin is not a function` using agendash as middleware. The same is described in #68. This PR is just a quickfix, it skips version check if it is not supported.