### PR TITLE
Add --path option, or $BASE_PATH environment variable for standalone version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,8 @@ FROM node:8.2.0-alpine
 
 ENV NODE_ENV=production \
   MONGODB_URI=mongodb://mongodb \
-  COLLECTION=agendaJobs
+  COLLECTION=agendaJobs \
+  BASE_PATH=/
 
 RUN mkdir -p /agendash
 WORKDIR /agendash

--- a/bin/agendash-standalone.js
+++ b/bin/agendash-standalone.js
@@ -18,7 +18,7 @@ if (!program.db) {
   process.exit(1);
 }
 
-if (program.basePath && program.basePath[0] !== '/') {
+if (program.basePath && !program.basePath.startsWith('/')) {
   console.error('--path must begin with /');
   process.exit(1);
 }
@@ -26,7 +26,7 @@ if (program.basePath && program.basePath[0] !== '/') {
 const app = express();
 
 const agenda = new Agenda().database(program.db, program.collection);
-app.use(program.path, require('../app')(agenda, {
+app.use(program.basePath, require('../app')(agenda, {
   title: program.title
 }));
 

--- a/bin/agendash-standalone.js
+++ b/bin/agendash-standalone.js
@@ -9,6 +9,7 @@ program
   .option('-d, --db <db>', '[required] Mongo connection string, same as Agenda connection string')
   .option('-c, --collection <collection>', '[optional] Mongo collection, same as Agenda collection name, default agendaJobs', 'agendaJobs')
   .option('-p, --port <port>', '[optional] Server port, default 3000', (n, d) => Number(n) || d, 3000)
+  .option('--path <basePath>', '[optional] Base path, default /', '/')
   .option('-t, --title <title>', '[optional] Page title, default Agendash', 'Agendash')
   .parse(process.argv);
 
@@ -17,10 +18,15 @@ if (!program.db) {
   process.exit(1);
 }
 
+if (program.basePath && program.basePath[0] !== '/') {
+  console.error('--path must begin with /');
+  process.exit(1);
+}
+
 const app = express();
 
 const agenda = new Agenda().database(program.db, program.collection);
-app.use('/', require('../app')(agenda, {
+app.use(program.path, require('../app')(agenda, {
   title: program.title
 }));
 
@@ -28,5 +34,5 @@ app.set('port', program.port);
 
 const server = http.createServer(app);
 server.listen(program.port, () => {
-  console.log(`Agendash started http://localhost:${program.port}`);
+  console.log(`Agendash started http://localhost:${program.port}${program.basePath}`);
 });

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,4 +2,4 @@
 
 set +e
 
-exec node ./bin/agendash-standalone.js --db=$MONGODB_URI --collection=$COLLECTION
+exec node ./bin/agendash-standalone.js --db=$MONGODB_URI --collection=$COLLECTION --path=$BASE_PATH


### PR DESCRIPTION
Add --path option, or $BASE_PATH environment variable for standalone version, so Docker users may be able to custom base path of the application.