### PR TITLE
Adds docker instructions to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,16 @@ If you are using npm >= 5.2, then you can use [npx](https://medium.com/@maybekat
 npx agendash --db=mongodb://localhost/agendaDb --collection=agendaCollection --port=3001
 ```
 
+### Docker usage
+
+Agendash can also be run within a Docker container like this: 
+
+```bash
+docker run -p 3000:3000 \
+  --env MONGODB_URI=mongo://myUser:myPass@myHost/myDb \
+  --env COLLECTION=myAgendaCollection agenda/agendash \
+```
+
 ### Middleware usage
 
 Agendash provides Express middleware you can use at a specified path, for example this will


### PR DESCRIPTION
These instructions were added as a comment of PR #76. 

There should be at README