### PR TITLE
Show new attribute 'result' to job in job-item-details-template as 'Execution result'

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -160,6 +160,10 @@
             <strong>Failure reason</strong>
             <pre><%- JSON.stringify(job.failReason || '', null, 2) %></pre>
           <% } %>
+          <% if (completed) { %>
+            <strong>Execution result</strong>
+            <pre><%- JSON.stringify(job.result || '', null, 2) %></pre>
+          <% } %>
         </div>
         <div class="panel-footer clearfix">
           <button type="button" class="btn btn-danger btn-sm" data-action="requeue">Requeue</button>


### PR DESCRIPTION
Show in job details the result of the job's execution, This could be helpful to debug or to show relevant information. Related to [#844](https://github.com/agenda/agenda/pull/844) 