### PR TITLE
Remove hapi from prod deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -236,6 +236,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/@hapi/accept/-/accept-5.0.1.tgz",
       "integrity": "sha512-fMr4d7zLzsAXo28PRRQPXR1o2Wmu+6z+VY1UzDp0iFo13Twj8WePakwXBiqn3E1aAlTpSNzCXdnnQXFhst8h8Q==",
+      "dev": true,
       "requires": {
         "@hapi/boom": "9.x.x",
         "@hapi/hoek": "9.x.x"
@@ -245,6 +246,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/@hapi/address/-/address-4.1.0.tgz",
       "integrity": "sha512-SkszZf13HVgGmChdHo/PxchnSaCJ6cetVqLzyciudzZRT0jcOouIF/Q93mgjw8cce+D+4F4C1Z/WrfFN+O3VHQ==",
+      "dev": true,
       "requires": {
         "@hapi/hoek": "^9.0.0"
       }
@@ -253,6 +255,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/@hapi/ammo/-/ammo-5.0.1.tgz",
       "integrity": "sha512-FbCNwcTbnQP4VYYhLNGZmA76xb2aHg9AMPiy18NZyWMG310P5KdFGyA9v2rm5ujrIny77dEEIkMOwl0Xv+fSSA==",
+      "dev": true,
       "requires": {
         "@hapi/hoek": "9.x.x"
       }
@@ -261,6 +264,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/@hapi/b64/-/b64-5.0.0.tgz",
       "integrity": "sha512-ngu0tSEmrezoiIaNGG6rRvKOUkUuDdf4XTPnONHGYfSGRmDqPZX5oJL6HAdKTo1UQHECbdB4OzhWrfgVppjHUw==",
+      "dev": true,
       "requires": {
         "@hapi/hoek": "9.x.x"
       }
@@ -269,6 +273,7 @@
       "version": "9.1.1",
       "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-9.1.1.tgz",
       "integrity": "sha512-VNR8eDbBrOxBgbkddRYIe7+8DZ+vSbV6qlmaN2x7eWjsUjy2VmQgChkOKcVZIeupEZYj+I0dqNg430OhwzagjA==",
+      "dev": true,
       "requires": {
         "@hapi/hoek": "9.x.x"
       }
@@ -277,6 +282,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@hapi/bounce/-/bounce-2.0.0.tgz",
       "integrity": "sha512-JesW92uyzOOyuzJKjoLHM1ThiOvHPOLDHw01YV8yh5nCso7sDwJho1h0Ad2N+E62bZyz46TG3xhAi/78Gsct6A==",
+      "dev": true,
       "requires": {
         "@hapi/boom": "9.x.x",
         "@hapi/hoek": "9.x.x"
@@ -285,12 +291,14 @@
     "@hapi/bourne": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-2.0.0.tgz",
-      "integrity": "sha512-WEezM1FWztfbzqIUbsDzFRVMxSoLy3HugVcux6KDDtTqzPsLE8NDRHfXvev66aH1i2oOKKar3/XDjbvh/OUBdg=="
+      "integrity": "sha512-WEezM1FWztfbzqIUbsDzFRVMxSoLy3HugVcux6KDDtTqzPsLE8NDRHfXvev66aH1i2oOKKar3/XDjbvh/OUBdg==",
+      "dev": true
     },
     "@hapi/call": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/@hapi/call/-/call-8.0.1.tgz",
       "integrity": "sha512-bOff6GTdOnoe5b8oXRV3lwkQSb/LAWylvDMae6RgEWWntd0SHtkYbQukDHKlfaYtVnSAgIavJ0kqszF/AIBb6g==",
+      "dev": true,
       "requires": {
         "@hapi/boom": "9.x.x",
         "@hapi/hoek": "9.x.x"
@@ -300,6 +308,7 @@
       "version": "11.1.1",
       "resolved": "https://registry.npmjs.org/@hapi/catbox/-/catbox-11.1.1.tgz",
       "integrity": "sha512-u/8HvB7dD/6X8hsZIpskSDo4yMKpHxFd7NluoylhGrL6cUfYxdQPnvUp9YU2C6F9hsyBVLGulBd9vBN1ebfXOQ==",
+      "dev": true,
       "requires": {
         "@hapi/boom": "9.x.x",
         "@hapi/hoek": "9.x.x",
@@ -311,6 +320,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/@hapi/catbox-memory/-/catbox-memory-5.0.0.tgz",
       "integrity": "sha512-ByuxVJPHNaXwLzbBv4GdTr6ccpe1nG+AfYt+8ftDWEJY7EWBWzD+Klhy5oPTDGzU26pNUh1e7fcYI1ILZRxAXQ==",
+      "dev": true,
       "requires": {
         "@hapi/boom": "9.x.x",
         "@hapi/hoek": "9.x.x"
@@ -320,6 +330,7 @@
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/@hapi/content/-/content-5.0.2.tgz",
       "integrity": "sha512-mre4dl1ygd4ZyOH3tiYBrOUBzV7Pu/EOs8VLGf58vtOEECWed8Uuw6B4iR9AN/8uQt42tB04qpVaMyoMQh0oMw==",
+      "dev": true,
       "requires": {
         "@hapi/boom": "9.x.x"
       }
@@ -328,6 +339,7 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/@hapi/cryptiles/-/cryptiles-5.1.0.tgz",
       "integrity": "sha512-fo9+d1Ba5/FIoMySfMqPBR/7Pa29J2RsiPrl7bkwo5W5o+AN1dAYQRi4SPrPwwVxVGKjgLOEWrsvt1BonJSfLA==",
+      "dev": true,
       "requires": {
         "@hapi/boom": "9.x.x"
       }
@@ -335,17 +347,20 @@
     "@hapi/file": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@hapi/file/-/file-2.0.0.tgz",
-      "integrity": "sha512-WSrlgpvEqgPWkI18kkGELEZfXr0bYLtr16iIN4Krh9sRnzBZN6nnWxHFxtsnP684wueEySBbXPDg/WfA9xJdBQ=="
+      "integrity": "sha512-WSrlgpvEqgPWkI18kkGELEZfXr0bYLtr16iIN4Krh9sRnzBZN6nnWxHFxtsnP684wueEySBbXPDg/WfA9xJdBQ==",
+      "dev": true
     },
     "@hapi/formula": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@hapi/formula/-/formula-2.0.0.tgz",
-      "integrity": "sha512-V87P8fv7PI0LH7LiVi8Lkf3x+KCO7pQozXRssAHNXXL9L1K+uyu4XypLXwxqVDKgyQai6qj3/KteNlrqDx4W5A=="
+      "integrity": "sha512-V87P8fv7PI0LH7LiVi8Lkf3x+KCO7pQozXRssAHNXXL9L1K+uyu4XypLXwxqVDKgyQai6qj3/KteNlrqDx4W5A==",
+      "dev": true
     },
     "@hapi/hapi": {
       "version": "19.2.0",
       "resolved": "https://registry.npmjs.org/@hapi/hapi/-/hapi-19.2.0.tgz",
       "integrity": "sha512-Isf/BUPQMRMYK+xx4y2B05lrrGw6PSbJKytk1SlaXeV7tXm6m+6tFRBog6c/na0QNgojafb0bjMB+vBg64CwUA==",
+      "dev": true,
       "requires": {
         "@hapi/accept": "^5.0.1",
         "@hapi/ammo": "^5.0.1",
@@ -371,6 +386,7 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/@hapi/heavy/-/heavy-7.0.1.tgz",
       "integrity": "sha512-vJ/vzRQ13MtRzz6Qd4zRHWS3FaUc/5uivV2TIuExGTM9Qk+7Zzqj0e2G7EpE6KztO9SalTbiIkTh7qFKj/33cA==",
+      "dev": true,
       "requires": {
         "@hapi/boom": "9.x.x",
         "@hapi/hoek": "9.x.x",
@@ -380,12 +396,14 @@
     "@hapi/hoek": {
       "version": "9.1.1",
       "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.1.1.tgz",
-      "integrity": "sha512-CAEbWH7OIur6jEOzaai83jq3FmKmv4PmX1JYfs9IrYcGEVI/lyL1EXJGCj7eFVJ0bg5QR8LMxBlEtA+xKiLpFw=="
+      "integrity": "sha512-CAEbWH7OIur6jEOzaai83jq3FmKmv4PmX1JYfs9IrYcGEVI/lyL1EXJGCj7eFVJ0bg5QR8LMxBlEtA+xKiLpFw==",
+      "dev": true
     },
     "@hapi/inert": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/@hapi/inert/-/inert-6.0.3.tgz",
       "integrity": "sha512-Z6Pi0Wsn2pJex5CmBaq+Dky9q40LGzXLUIUFrYpDtReuMkmfy9UuUeYc4064jQ1Xe9uuw7kbwE6Fq6rqKAdjAg==",
+      "dev": true,
       "requires": {
         "@hapi/ammo": "5.x.x",
         "@hapi/boom": "9.x.x",
@@ -399,6 +417,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/@hapi/iron/-/iron-6.0.0.tgz",
       "integrity": "sha512-zvGvWDufiTGpTJPG1Y/McN8UqWBu0k/xs/7l++HVU535NLHXsHhy54cfEMdW7EjwKfbBfM9Xy25FmTiobb7Hvw==",
+      "dev": true,
       "requires": {
         "@hapi/b64": "5.x.x",
         "@hapi/boom": "9.x.x",
@@ -411,6 +430,7 @@
       "version": "17.1.1",
       "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-17.1.1.tgz",
       "integrity": "sha512-p4DKeZAoeZW4g3u7ZeRo+vCDuSDgSvtsB/NpfjXEHTUjSeINAi/RrVOWiVQ1isaoLzMvFEhe8n5065mQq1AdQg==",
+      "dev": true,
       "requires": {
         "@hapi/address": "^4.0.1",
         "@hapi/formula": "^2.0.0",
@@ -423,6 +443,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/@hapi/mimos/-/mimos-5.0.0.tgz",
       "integrity": "sha512-EVS6wJYeE73InTlPWt+2e3Izn319iIvffDreci3qDNT+t3lA5ylJ0/SoTaID8e0TPNUkHUSsgJZXEmLHvoYzrA==",
+      "dev": true,
       "requires": {
         "@hapi/hoek": "9.x.x",
         "mime-db": "1.x.x"
@@ -432,6 +453,7 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@hapi/nigel/-/nigel-4.0.2.tgz",
       "integrity": "sha512-ht2KoEsDW22BxQOEkLEJaqfpoKPXxi7tvabXy7B/77eFtOyG5ZEstfZwxHQcqAiZhp58Ae5vkhEqI03kawkYNw==",
+      "dev": true,
       "requires": {
         "@hapi/hoek": "^9.0.4",
         "@hapi/vise": "^4.0.0"
@@ -441,6 +463,7 @@
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/@hapi/pez/-/pez-5.0.3.tgz",
       "integrity": "sha512-mpikYRJjtrbJgdDHG/H9ySqYqwJ+QU/D7FXsYciS9P7NYBXE2ayKDAy3H0ou6CohOCaxPuTV4SZ0D936+VomHA==",
+      "dev": true,
       "requires": {
         "@hapi/b64": "5.x.x",
         "@hapi/boom": "9.x.x",
@@ -452,12 +475,14 @@
     "@hapi/pinpoint": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@hapi/pinpoint/-/pinpoint-2.0.0.tgz",
-      "integrity": "sha512-vzXR5MY7n4XeIvLpfl3HtE3coZYO4raKXW766R6DZw/6aLqR26iuZ109K7a0NtF2Db0jxqh7xz2AxkUwpUFybw=="
+      "integrity": "sha512-vzXR5MY7n4XeIvLpfl3HtE3coZYO4raKXW766R6DZw/6aLqR26iuZ109K7a0NtF2Db0jxqh7xz2AxkUwpUFybw==",
+      "dev": true
     },
     "@hapi/podium": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/@hapi/podium/-/podium-4.1.1.tgz",
       "integrity": "sha512-jh7a6+5Z4FUWzx8fgmxjaAa1DTBu+Qfg+NbVdo0f++rE5DgsVidUYrLDp3db65+QjDLleA2MfKQXkpT8ylBDXA==",
+      "dev": true,
       "requires": {
         "@hapi/hoek": "9.x.x",
         "@hapi/teamwork": "5.x.x",
@@ -467,7 +492,8 @@
         "@hapi/teamwork": {
           "version": "5.1.0",
           "resolved": "https://registry.npmjs.org/@hapi/teamwork/-/teamwork-5.1.0.tgz",
-          "integrity": "sha512-llqoQTrAJDTXxG3c4Kz/uzhBS1TsmSBa/XG5SPcVXgmffHE1nFtyLIK0hNJHCB3EuBKT84adzd1hZNY9GJLWtg=="
+          "integrity": "sha512-llqoQTrAJDTXxG3c4Kz/uzhBS1TsmSBa/XG5SPcVXgmffHE1nFtyLIK0hNJHCB3EuBKT84adzd1hZNY9GJLWtg==",
+          "dev": true
         }
       }
     },
@@ -475,6 +501,7 @@
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@hapi/shot/-/shot-5.0.4.tgz",
       "integrity": "sha512-PcEz0WJgFDA3xNSMeONgQmothFr7jhbbRRSAKaDh7chN7zOXBlhl13bvKZW6CMb2xVfJUmt34CW3e/oExMgBhQ==",
+      "dev": true,
       "requires": {
         "@hapi/hoek": "9.x.x",
         "@hapi/validate": "1.x.x"
@@ -484,6 +511,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@hapi/somever/-/somever-3.0.0.tgz",
       "integrity": "sha512-Upw/kmKotC9iEmK4y047HMYe4LDKsE5NWfjgX41XNKmFvxsQL7OiaCWVhuyyhU0ShDGBfIAnCH8jZr49z/JzZA==",
+      "dev": true,
       "requires": {
         "@hapi/bounce": "2.x.x",
         "@hapi/hoek": "9.x.x"
@@ -493,6 +521,7 @@
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/@hapi/statehood/-/statehood-7.0.3.tgz",
       "integrity": "sha512-pYB+pyCHkf2Amh67QAXz7e/DN9jcMplIL7Z6N8h0K+ZTy0b404JKPEYkbWHSnDtxLjJB/OtgElxocr2fMH4G7w==",
+      "dev": true,
       "requires": {
         "@hapi/boom": "9.x.x",
         "@hapi/bounce": "2.x.x",
@@ -507,6 +536,7 @@
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/@hapi/subtext/-/subtext-7.0.3.tgz",
       "integrity": "sha512-CekDizZkDGERJ01C0+TzHlKtqdXZxzSWTOaH6THBrbOHnsr3GY+yiMZC+AfNCypfE17RaIakGIAbpL2Tk1z2+A==",
+      "dev": true,
       "requires": {
         "@hapi/boom": "9.x.x",
         "@hapi/bourne": "2.x.x",
@@ -520,12 +550,14 @@
     "@hapi/teamwork": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@hapi/teamwork/-/teamwork-4.0.0.tgz",
-      "integrity": "sha512-V6xYOrr5aFv/IJqNPneaYCu8vuGTKisamqHVRS3JJnbZr18TrpXdsJOYk9pjPhFti+M2YETPebQLUr820N5NoQ=="
+      "integrity": "sha512-V6xYOrr5aFv/IJqNPneaYCu8vuGTKisamqHVRS3JJnbZr18TrpXdsJOYk9pjPhFti+M2YETPebQLUr820N5NoQ==",
+      "dev": true
     },
     "@hapi/topo": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.0.0.tgz",
       "integrity": "sha512-tFJlT47db0kMqVm3H4nQYgn6Pwg10GTZHb1pwmSiv1K4ks6drQOtfEF5ZnPjkvC+y4/bUPHK+bc87QvLcL+WMw==",
+      "dev": true,
       "requires": {
         "@hapi/hoek": "^9.0.0"
       }
@@ -534,6 +566,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@hapi/validate/-/validate-1.1.3.tgz",
       "integrity": "sha512-/XMR0N0wjw0Twzq2pQOzPBZlDzkekGcoCtzO314BpIEsbXdYGthQUbxgkGDf4nhk1+IPDAsXqWjMohRQYO06UA==",
+      "dev": true,
       "requires": {
         "@hapi/hoek": "^9.0.0",
         "@hapi/topo": "^5.0.0"
@@ -543,6 +576,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@hapi/vise/-/vise-4.0.0.tgz",
       "integrity": "sha512-eYyLkuUiFZTer59h+SGy7hUm+qE9p+UemePTHLlIWppEd+wExn3Df5jO04bFQTm7nleF5V8CtuYQYb+VFpZ6Sg==",
+      "dev": true,
       "requires": {
         "@hapi/hoek": "9.x.x"
       }
@@ -551,6 +585,7 @@
       "version": "17.1.0",
       "resolved": "https://registry.npmjs.org/@hapi/wreck/-/wreck-17.1.0.tgz",
       "integrity": "sha512-nx6sFyfqOpJ+EFrHX+XWwJAxs3ju4iHdbB/bwR8yTNZOiYmuhA8eCe7lYPtYmb4j7vyK/SlbaQsmTtUrMvPEBw==",
+      "dev": true,
       "requires": {
         "@hapi/boom": "9.x.x",
         "@hapi/bourne": "2.x.x",
@@ -4659,6 +4694,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
       "requires": {
         "yallist": "^4.0.0"
       }
@@ -7947,7 +7983,8 @@
     "yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     },
     "yaml": {
       "version": "1.10.0",

--- a/package.json
+++ b/package.json
@@ -30,8 +30,6 @@
   "homepage": "https://github.com/agenda/agendash#readme",
   "license": "MIT",
   "dependencies": {
-    "@hapi/hapi": "^19.1.1",
-    "@hapi/inert": "^6.0.1",
     "agenda": "^3.1.0 || ^4.0.0",
     "body-parser": "^1.15.0",
     "commander": "^2.9.0",
@@ -40,6 +38,8 @@
     "semver": "^5.3.0"
   },
   "devDependencies": {
+    "@hapi/hapi": "^19.1.1",
+    "@hapi/inert": "^6.0.1",
     "ava": "^3.5.1",
     "npm-run-all": "^4.1.2",
     "supertest": "^3.0.0",


### PR DESCRIPTION
Fixes #136
This PR should be merged after #144 is merged.

This removes Hapi from production dependencies. No public API depends on Hapi.

I'm not removing Express from prod deps. because the CLI command depends on it. It would be too much of the breaking change if we ask people to install Express along with the Agendash. Also, it would break `npx `.