### PR TITLE
fix: coerce version

### DIFF
--- a/lib/controllers/agendash.js
+++ b/lib/controllers/agendash.js
@@ -27,7 +27,7 @@ module.exports = function (agenda, options) {
         throw error;
       }
 
-      if (!semver.satisfies(serverInfo.version, ">=2.6.0")) {
+      if (!semver.satisfies(semver.coerce(serverInfo.version), ">=2.6.0")) {
         throw new Error("MongoDB version not supported");
       }
     });


### PR DESCRIPTION
`semver.satisfies('4.4.6-psmdb', '>=2.6.0')` => `false`
`semver.satisfies(semver.coerce('4.4.6-psmdb'), '>=2.6.0')` => `true`