### PR TITLE
css: allow job detail modal to fill the screen

### DIFF
--- a/public/app/css/styles.css
+++ b/public/app/css/styles.css
@@ -122,8 +122,20 @@ code {
   margin: 0 2px;
 }
 
+.job-detail-dialog {
+  max-width: calc(100vw - 1.75rem * 2);
+}
+.modal-body > * {
+  flex: 0 1 auto;
+}
+.modal-body {
+  display: flex;
+  flex-flow: column;
+  max-height: calc(100vh - 195px);
+}
+
 .json-editor {
-  height: 150px;
+  flex: 1 1 auto;
 }
 .card-responsive-title-container {
   display: flex;

--- a/public/app/js/jobdetail.js
+++ b/public/app/js/jobdetail.js
@@ -13,7 +13,7 @@ const jobDetail = Vue.component("job-detail", {
   template: `
   <div class="modal fade" id="modalData" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">
       <!-- Modal -->
-    <div class="modal-dialog" role="document">
+    <div class="modal-dialog job-detail-dialog" role="document">
       <div class="modal-content">
         <div class="modal-header">
           <h5 class="modal-title" id="exampleModalLabel">Job Data - {{job.job.name}}</h5>


### PR DESCRIPTION
By default the job detail modal is small and with a large amount of json can be hard to nagivate.
![image](https://user-images.githubusercontent.com/3621017/153661838-f87a6009-7a40-4c92-bf1e-a95be3e9a0b6.png)  

This simply PR allows this modal to fill the screen.  
![image](https://user-images.githubusercontent.com/3621017/153662424-4e55292b-a6a5-4cfe-bc05-6231f2d0a063.png)

The height of the modal with automatically adjust based on the content. The width of the modal will always fill the screen.