### PR TITLE
Fixes ObjectId constructor usage on agendash controller

### DIFF
--- a/lib/controllers/agendash.js
+++ b/lib/controllers/agendash.js
@@ -42,7 +42,7 @@ module.exports = function (agenda, options) {
 
     if (options.query && options.property) {
       if (options.isObjectId) {
-        preMatch[options.property] = ObjectId(options.query);
+        preMatch[options.property] = new ObjectId(options.query);
       } else if (/^\d+$/.test(options.query)) {
         preMatch[options.property] = Number.parseInt(options.query, 10);
       } else {
@@ -284,7 +284,7 @@ module.exports = function (agenda, options) {
     const collection = agenda._collection.collection || agenda._collection;
     const jobs = await collection
       .find({
-        _id: { $in: jobIds.map((jobId) => ObjectId(jobId)) },
+        _id: { $in: jobIds.map((jobId) => new ObjectId(jobId)) },
       })
       .toArray();
     if (jobs.length === 0) {
@@ -306,7 +306,7 @@ module.exports = function (agenda, options) {
     }
 
     return agenda.cancel({
-      _id: { $in: jobIds.map((jobId) => ObjectId(jobId)) },
+      _id: { $in: jobIds.map((jobId) => new ObjectId(jobId)) },
     });
   };
 


### PR DESCRIPTION
**_Context:_**
I was experiencing issues when trying to Requeue and Delete jobs using Agendash receiving a 404 error.
![image](https://user-images.githubusercontent.com/4092786/217275708-d5c7b4ae-58da-4218-befa-bbf3b0eca69a.png)

**_Issue:_**
Adding some logs on the agendash controller found that ObjectId was being used in a wrong way:
![image](https://user-images.githubusercontent.com/4092786/217275964-e5ec7df9-9112-4a39-a9e9-31267e4bfd45.png)

**_Fix:_**
Added `new` to each ObjectId call on the agendash controller
![image](https://user-images.githubusercontent.com/4092786/217276372-de992c86-3d06-4245-8a9a-5e866a7e7442.png)
