### PR TITLE
Display human representation of cron patterns using "cronstrue" library.

### DIFF
--- a/lib/controllers/agendash.js
+++ b/lib/controllers/agendash.js
@@ -1,7 +1,22 @@
 "use strict";
 const semver = require("semver");
 const { ObjectId } = require("mongodb"); // We rely on the Agenda's "mongodb", thus our package.json lists "*" as required version
+const cronstrue = require("cronstrue"); // gets a human representation of the cron interval
 
+/**
+ * Get a human representation of the cron interval
+ * @param {string} repeatInterval - a cron interval e.g. "0 0 * * *"
+ * @returns {string} human representation of the cron interval e.g. "Every day at 00:00"
+ */
+const getHumanRepeatInterval = (repeatInterval) => {
+  let result = repeatInterval;
+  // if the repeat interval doesn't have at least 5 spaces, it's not a cron expression, in which case just return the original value
+  const isRepeatIntervalCronExpr = !!(repeatInterval.split(" ").length > 4);
+  if (isRepeatIntervalCronExpr) {
+    result = cronstrue.toString(repeatInterval, { verbose: true, throwExceptionOnParseError: false });
+  }
+  return result;
+}
 module.exports = function (agenda, options) {
   options = options || {};
 
@@ -34,7 +49,7 @@ module.exports = function (agenda, options) {
   });
 
   // Options = {query = '', property = '', isObjectId = false, limit, skip}
-  const getJobs = function (job, state, options) {
+  const getJobs = async (job, state, options) => {
     const preMatch = {};
     if (job) {
       preMatch.name = job;
@@ -56,7 +71,7 @@ module.exports = function (agenda, options) {
     }
 
     const collection = agenda._collection.collection || agenda._collection;
-    return collection
+    const jobsQueryResult = await collection
       .aggregate([
         { $match: preMatch },
         {
@@ -118,8 +133,17 @@ module.exports = function (agenda, options) {
             filtered: [{ $skip: options.skip }, { $limit: options.limit }],
           },
         },
-      ])
-      .toArray();
+      ]).toArray();
+
+      // add a human representation of the cron interval for each job
+      jobsQueryResult?.[0]?.filtered?.forEach((job) => {
+        const repeatIntervalHuman = getHumanRepeatInterval(job.job.repeatInterval);
+        if (repeatIntervalHuman !== job.job.repeatInterval) { // only add the human representation if it's different from the cron expression
+          job.job.repeatIntervalHuman = repeatIntervalHuman;
+        }
+      });
+
+      return jobsQueryResult;
   };
 
   const getOverview = async () => {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "agenda": "^4.2.1",
     "body-parser": "^1.19.2",
     "commander": "^2.9.0",
+    "cronstrue": "^2.28.0",
     "express": "^4.17.3",
     "mongodb": "*",
     "semver": "^7.3.4"

--- a/public/app/js/joblist.js
+++ b/public/app/js/joblist.js
@@ -142,6 +142,7 @@ const jobList = Vue.component("job-list", {
                   </td>
                   <td th scope="row" class="job-name">
                     <i v-if="job.repeating" class="oi oi-timer pill-own bg-info"><span>{{job.job.repeatInterval}}</span></i>
+                    <i v-if="job.job.repeatIntervalHuman" class="oi oi-timer pill-own bg-info"><span>{{job.job.repeatIntervalHuman}}</span></i>
                     <i v-if="job.scheduled" class="pill-own bg-info pill-withoutIcon"><span>Scheduled</span></i>
                     <i v-if="job.completed" class="pill-own bg-success pill-withoutIcon"><span>Completed</span></i>
                     <i v-if="job.queued" class="pill-own bg-primary pill-withoutIcon"><span>Queued</span></i>
@@ -183,6 +184,7 @@ const jobList = Vue.component("job-list", {
                 <div class="card-body">
                   <div class="d-flex justify-content-center mb-2">
                     <i v-if="job.repeating" class="oi oi-timer pill-own mr-2 bg-info pill-own-card"><span class="pill-own-card-info">{{job.job.repeatInterval}}</span></i>
+                    <i v-if="job.job.repeatIntervalHuman" class="oi oi-timer pill-own mr-2 bg-info pill-own-card"><span class="pill-own-card-info">{{job.job.repeatIntervalHuman}}</span></i>
                     <i v-if="job.scheduled" class="pill-own mr-2 bg-info pill-withoutIcon pill-own-card"><span class="pill-own-card-info">Scheduled</span></i>
                     <i v-if="job.completed" class="pill-own mr-2 bg-success pill-withoutIcon pill-own-card"><span class="pill-own-card-info">Completed</span></i>
                     <i v-if="job.queued" class="pill-own mr-2 bg-primary pill-withoutIcon pill-own-card"><span class="pill-own-card-info">Queued</span></i>


### PR DESCRIPTION
Display descriptions of crontab repeat patterns e.g. `0 05 05 * * */1` displays as `At 05:05 AM, every day`.
Uses the [cronstrue](https://www.npmjs.com/package/cronstrue) library.

See attached screenshots.
<img width="1136" alt="Screenshot 2023-08-09 at 2 27 46 pm" src="https://github.com/agenda/agendash/assets/1751645/b7e25ad9-1973-4ba6-b68f-97d025bad37c">

<img width="1418" alt="Screenshot 2023-08-09 at 2 28 31 pm" src="https://github.com/agenda/agendash/assets/1751645/44d08f21-e805-4f38-95be-c0dc1e6b580c">
